### PR TITLE
adds env.json file

### DIFF
--- a/src/env.json
+++ b/src/env.json
@@ -1,0 +1,3 @@
+{
+  "OCD_API_KEY": "6d0e711d72d74daeb2b0bfd2a5cdfdba"
+}

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -15,7 +15,7 @@ import GlobeIcon from '../components/GlobeIcon';
 import RefreshIcon from '../components/RefreshIcon';
 import GeocodingResult from '../components/GeocodinigResult';
 
-const OCD_API_KEY = '6d0e711d72d74daeb2b0bfd2a5cdfdba';
+import { OCD_API_KEY } from '../env.json';
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
Add an `env.json` file in order to store the OpenCage Data API Key. [Test key](https://opencagedata.com/api#testingkeys) returning always the same result is provided.

build script can then override this file with an valid API key